### PR TITLE
groups: add support for groups from oauth-challange

### DIFF
--- a/Template/config/integration.php
+++ b/Template/config/integration.php
@@ -40,6 +40,10 @@
     <?= $this->form->text('oauth2_email_domains', $values) ?>
     <p class="form-help"><?= t('Use a comma to enter multiple domains: domain1.tld, domain2.tld') ?></p>
 
+    <?= $this->form->label(t('Groups Key'), 'oauth2_key_groups') ?>
+    <?= $this->form->text('oauth2_key_groups', $values) ?>
+    <p class="form-help"><?= t('Leave empty, when no group mapping is wanted') ?></p>
+
     <div class="form-actions">
         <input type="submit" value="<?= t('Save') ?>" class="btn btn-blue"/>
     </div>

--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -159,17 +159,16 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
     {
         $groups = $this->getKey('oauth2_key_groups');
 
-        if ( empty($groups)) {
-            $this->logger->debug('OAuth2: ' . $this->getUsername() . ' has no groups');
+        if (empty($groups)) {
+            $this->logger->debug('OAuth2: '.$this->getUsername().' has no groups');
             return array();
         }
 
         $groups = array_unique($groups);
-        $this->logger->debug('OAuth2: ' . $this->getUsername() . ' groups are '. join(',',$groups));
+        $this->logger->debug('OAuth2: '.$this->getUsername().' groups are '. join(',', $groups));
 
-        // create a external group, if not exists
-        foreach( $groups as $group) {
-            $this->groupModel->getOrCreateExternalGroupId( $group, $group);
+        foreach ($groups as $group) {
+            $this->groupModel->getOrCreateExternalGroupId($group, $group);
         }
 
         return $groups;

--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -157,7 +157,22 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
      */
     public function getExternalGroupIds()
     {
-        return array();
+        $groups = $this->getKey('oauth2_key_groups');
+
+        if ( empty($groups)) {
+            $this->logger->debug('OAuth2: ' . $this->getUsername() . ' has no groups');
+            return array();
+        }
+
+        $groups = array_unique($groups);
+        $this->logger->debug('OAuth2: ' . $this->getUsername() . ' groups are '. join(',',$groups));
+
+        // create a external group, if not exists
+        foreach( $groups as $group) {
+            $this->groupModel->getOrCreateExternalGroupId( $group, $group);
+        }
+
+        return $groups;
     }
 
     /**


### PR DESCRIPTION
- reads the groups from a selectable oauth field
- create not existing groups at login as external group in the db

oauth has no possiblity to fetch the groups directly.
this implies to create the groups at login and do not use an own GroupsBackend.