### PR TITLE
fix getKey error when userinfo with nested structure

### DIFF
--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -219,7 +219,11 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
 
     protected function getKey($key)
     {
-        $key = $this->configModel->get($key);
-        return ! empty($key) && isset($this->userData[$key]) ? $this->userData[$key] : '';
+        $key   = explode('.', $this->configModel->get($key));
+        $value = $this->userData;
+        foreach ($key as $k) {
+            $value = $value[$k];
+        }
+        return ! empty($key) && isset($value) ? $value : '';
     }
 }


### PR DESCRIPTION
for example some OAuth2 provider provide multiple emails like this:

```
{
  "_id": "aobEdbYhXfu5hkeqG",
  "name": "Example User",
  "emails": [
    {
      "address": "example1@example.com",
      "primary": true
    },
    {
      "address": "example2@example.com",
      "primary": false
    }
  ],
  "status": "offline",
  "statusConnection": "offline",
  "username": "example",
  "utcOffset": 0,
......
```
we need get email address for email map in kanboard.

this patch use `.` as separator to get value from nested structure.

in this example we can use `emails.0.address` as key name to get first
email address.