### PR TITLE
fix getKey() error if Groups Key is left blank

### DIFF
--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -157,7 +157,13 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
      */
     public function getExternalGroupIds()
     {
-        $groups = $this->getKey('oauth2_key_groups');
+        $key = 'oauth2_key_groups';
+        
+        if (empty($this->configModel->get($key))) {
+            return array();
+        }
+        
+        $groups = $this->getKey($key);
 
         if (empty($groups)) {
             $this->logger->debug('OAuth2: '.$this->getUsername().' has no groups');


### PR DESCRIPTION
Check whether Groups Key is blank before sending it to $this->getKey(); otherwise it will log "PHP Notice:  Undefined index:  " because it's being asked to look for a blank key.