### PR TITLE
Add group filter

### DIFF
--- a/Template/config/integration.php
+++ b/Template/config/integration.php
@@ -44,6 +44,10 @@
     <?= $this->form->text('oauth2_key_groups', $values) ?>
     <p class="form-help"><?= t('Leave empty, when no group mapping is wanted') ?></p>
 
+    <?= $this->form->label(t('Group Filter'), 'oauth2_key_group_filter') ?>
+    <?= $this->form->text('oauth2_key_group_filter', $values) ?>
+    <p class="form-help"><?= t('Use a comma to enter multiple useable groups: group1,group2') ?></p>
+
     <div class="form-actions">
         <input type="submit" value="<?= t('Save') ?>" class="btn btn-blue"/>
     </div>

--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -198,7 +198,7 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
         $groupFilter = explode(',',$this->configModel->get('oauth2_key_group_filter'));
 
         foreach ($groups as $group) {
-            if ( $this->isGroupInFilter($group $filter) ) {
+            if ( $this->isGroupInFilter($group, $groupFilter)) {
                 $this->groupModel->getOrCreateExternalGroupId($group, $group);
                 array_push($filteredGroups, $group);
             } else {

--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -153,14 +153,13 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
      * @param string $group
      * @return boolean
      */
-    protected function isGroupInFilter(string $group) 
+    protected function isGroupInFilter(string $group, array $filter) 
     {
-        if (empty($this->configModel->get('oauth2_key_group_filter'))) {
+        if (empty($filter)) {
             $this->logger->debug('OAuth2: No group specified in filter. All provided groups will be used.');
             return true;
         } else {
-            $groupFilter = explode(',',$this->configModel->get('oauth2_key_group_filter'));
-            if (in_array($group, $groupFilter)) {
+            if (in_array($group, $filter)) {
                 return true;
             } else {
                 return false;
@@ -196,9 +195,10 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
         $this->logger->debug('OAuth2: '.$this->getUsername().' groups are '. join(',', $groups));
 
         $filteredGroups = array();
+        $groupFilter = explode(',',$this->configModel->get('oauth2_key_group_filter'));
 
         foreach ($groups as $group) {
-            if ( $this->isGroupInFilter($group) ) {
+            if ( $this->isGroupInFilter($group $filter) ) {
                 $this->groupModel->getOrCreateExternalGroupId($group, $group);
                 array_push($filteredGroups, $group);
             } else {


### PR DESCRIPTION
I added a new option in Integration Tab that allows to filter provided groups from oauth2.
If no filter is defined all groups are used.
Filter can be a comma-separated list of groups names: group1,group2
In this example only group1 and group2 will be used.