### PR TITLE
fix: groupsfilter is not ignored when filter value is empty

### DIFF
--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -195,7 +195,7 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
         $this->logger->debug('OAuth2: '.$this->getUsername().' groups are '. join(',', $groups));
 
         $filteredGroups = array();
-        $groupFilter = explode(',',$this->configModel->get('oauth2_key_group_filter'));
+        $groupFilter = array_filter(explode(',',$this->configModel->get('oauth2_key_group_filter')));
 
         foreach ($groups as $group) {
             if ( $this->isGroupInFilter($group, $groupFilter)) {


### PR DESCRIPTION
Exploding an empty string results in an array with one item.
`array_filter` can be used to fix this:

```
php > var_dump( explode(',', "") );
array(1) {
  [0]=> string(0) ""
}

php > var_dump( empty( explode(',', "") ) );
bool(false)

php > var_dump( array_filter( explode(',', "") ) );
array(0) {
}

php > var_dump( empty( array_filter( explode(',', "") ) ) );
bool(true)
```