### PR TITLE
Better handling of empty group filter

### DIFF
--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -195,7 +195,12 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
         $this->logger->debug('OAuth2: '.$this->getUsername().' groups are '. join(',', $groups));
 
         $filteredGroups = array();
-        $groupFilter = explode(',',$this->configModel->get('oauth2_key_group_filter'));
+        $groupFilter = array();
+
+        $confGroupFilter = $this->configModel->get('oauth2_key_group_filter');
+        if (!empty($confGroupFilter)) {
+            $groupFilter = explode(',',$confGroupFilter);
+        }
 
         foreach ($groups as $group) {
             if ( $this->isGroupInFilter($group, $groupFilter)) {


### PR DESCRIPTION
Check if oauth2_key_group_filter is empty before exploding it.
Else isGroupInFilter does not catch _if (empty($filter))_ because the $filter array contains 1.