### PR TITLE
Added a small improvement to the new Group Filtering Additions

### DIFF
--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -199,8 +199,8 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
 
         $confGroupFilter = $this->configModel->get('oauth2_key_group_filter');
         if (!empty($confGroupFilter)) {
-            $confGroupFilter = str_replace(', ', ',', $confGroupFilter);
-            $groupFilter = explode(',',$confGroupFilter);
+            $groupFilter = explode(',', $confGroupFilter);
+            $groupFilter = array_map('trim', $groupFilter);
         }
 
         foreach ($groups as $group) {

--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -199,6 +199,7 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
 
         $confGroupFilter = $this->configModel->get('oauth2_key_group_filter');
         if (!empty($confGroupFilter)) {
+            $confGroupFilter = str_replace(', ', ',', $confGroupFilter);
             $groupFilter = explode(',',$confGroupFilter);
         }
 


### PR DESCRIPTION
This is a reference to the comment I shared here:
https://github.com/kanboard/plugin-oauth2/commit/8b6cecd86364a4b79c88f72ac9e2372396a341ba#commitcomment-42857643

After applying the change the second group that was supposed to be added in upon login did get added to my record successfully (whereas it was only adding the first group before the comma before since I was just a comma+space separator on my end).