### PR TITLE
Add configuration flag to disable splitting keys on '.'

### DIFF
--- a/Template/config/integration.php
+++ b/Template/config/integration.php
@@ -33,6 +33,10 @@
     <?= $this->form->label(t('User ID Key'), 'oauth2_key_user_id') ?>
     <?= $this->form->text('oauth2_key_user_id', $values) ?>
 
+    <?= $this->form->hidden('oauth2_split_keys', array('oauth2_split_keys' => 0)) ?>
+    <?= $this->form->checkbox('oauth2_split_keys', t('Use composite keys?'), 1, isset($values['oauth2_split_keys']) && $values['oauth2_split_keys'] == 1) ?>
+    <p class="form-help"><?= t('Interpret \'.\' in keys as keys for sub-objects') ?></p>
+
     <?= $this->form->hidden('oauth2_account_creation', array('oauth2_account_creation' => 0)) ?>
     <?= $this->form->checkbox('oauth2_account_creation', t('Allow Account Creation'), 1, isset($values['oauth2_account_creation']) && $values['oauth2_account_creation'] == 1) ?>
 

--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -274,11 +274,21 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
 
     protected function getKey($key)
     {
-        $key   = explode('.', $this->configModel->get($key));
-        $value = $this->userData;
-        foreach ($key as $k) {
-            $value = $value[$k];
+        if($this->configModel->get('oauth2_split_keys') == 1) {
+            $key   = explode('.', $this->configModel->get($key));
+            $value = $this->userData;
+            foreach ($key as $k) {
+                $value = $value[$k];
+            }
+            return ! empty($key) && isset($value) ? $value : '';
+        } else {
+            $key = $this->configModel->get($key);
+            if(empty($key)) {
+                return '';
+            }
+
+            $value = $this->userData[$key];
+            return isset($value) ? $value : '';
         }
-        return ! empty($key) && isset($value) ? $value : '';
     }
 }

--- a/User/GenericOAuth2UserProvider.php
+++ b/User/GenericOAuth2UserProvider.php
@@ -206,6 +206,10 @@ class GenericOAuth2UserProvider extends Base implements UserProviderInterface
             return array();
         }
 
+        if(!is_array($groups)) {
+            $groups = array($groups);
+        }
+
         $groups = array_unique($groups);
         $this->logger->debug('OAuth2: '.$this->getUsername().' groups are '. join(',', $groups));
 


### PR DESCRIPTION
I recently set up an instance of Kanboard using this plugin to sign in users through Slack. As part of the set-up, I wanted to have users grouped by the id of the workspace associated with their slack account. The Slack [userInfo](https://api.slack.com/methods/openid.connect.userInfo) response does include this information under the key `https://slack.com/team_id`, so I configured the "Groups Key" to be `https://slack.com/team_id`. 

However, this created two issues:
1. The key `https://slack.com/team_id` contains a '.', causing the GenericOAuth2UserProvider::getKey function to split it up. Essentially, the plugin thought that the key was referring to a member of a sub-object of the response, when it was actually just a literal '.' in the key.
2. Once I fixed 1, I was still getting a crash. Turns out, the plugin expects the data returned from the "Groups Key" to be an array of groups. However, I was just getting a literal string, causing `array_unique` to throw an error.

My solution is the following:
1. Add a configuration option to disable splitting keys. None of my keys are composite, so I don't need the splitting functionality. So I added the `oauth2_split_keys` setting, which will disable key splitting when set to '0'.
2. Wrap the `$groups` in an array if it is not already an array. That way, if the "Groups Key" returns just a single group, it will be automatically wrapped into an array of length 1.